### PR TITLE
Fix Flutter 3.1 deprecated member use

### DIFF
--- a/packages/yaru_colors/example/lib/main.dart
+++ b/packages/yaru_colors/example/lib/main.dart
@@ -211,7 +211,7 @@ class ColorTile extends StatelessWidget {
     return DefaultTextStyle(
       style: TextStyle(
         fontFamily: 'Ubuntu Mono',
-        fontSize: Theme.of(context).textTheme.caption!.fontSize,
+        fontSize: Theme.of(context).textTheme.bodySmall!.fontSize,
         color: color.isDark ? YaruColors.porcelain : YaruColors.textGrey,
         fontWeight: isPrimary ? FontWeight.bold : FontWeight.normal,
       ),


### PR DESCRIPTION
```
'caption' is deprecated and shouldn't be used. Use bodySmall instead. This feature was deprecated after v3.1.0-0.0.pre.
Try replacing the use of the deprecated member with the replacement.
```