### PR TITLE
melos: choose between dart test vs. flutter test

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -40,8 +40,10 @@ scripts:
 
   # run tests in all packages
   test: >
-    melos exec -c 1 --fail-fast --dir-exists=test -- \
+    melos exec -c 1 --fail-fast --dir-exists=test --no-flutter -- \
       dart test
+    melos exec -c 1 --fail-fast --dir-exists=test --flutter -- \
+      flutter test
 
   # updates goldens in all packages
   update-goldens: >


### PR DESCRIPTION
The builder test requires dart:mirrors vs. the upcoming color tests require flutter test.