### PR TITLE
Docs: fix screenshot links

### DIFF
--- a/lib/src/colors.dart
+++ b/lib/src/colors.dart
@@ -17,7 +17,7 @@ class YaruColors {
 
   /// Ubuntu Orange
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/orange.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/orange.png)
   @GeneratedYaruColor(0xFFE95622)
   static const MaterialColor orange = _$YaruColors.orange;
 
@@ -29,7 +29,7 @@ class YaruColors {
   /// Warm grey can be used for; backgrounds, graphics, dot patterns, charts and
   /// diagrams. It can also be used for large size text.
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/warmGrey.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/warmGrey.png)
   @GeneratedYaruColor(0xFFAEA79F)
   static const MaterialColor warmGrey = _$YaruColors.warmGrey;
 
@@ -74,98 +74,98 @@ class YaruColors {
 
   /// Olive
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/olive.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/olive.png)
   @GeneratedYaruColor(0xFF4B8501)
   static const MaterialColor olive = _$YaruColors.olive;
 
   /// Bark
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/bark.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/bark.png)
   @GeneratedYaruColor(0xFF787859)
   static const MaterialColor bark = _$YaruColors.bark;
 
   /// Sage
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/sage.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/sage.png)
   @GeneratedYaruColor(0xFF657B69)
   static const MaterialColor sage = _$YaruColors.sage;
 
   /// Prussian Green
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/prussianGreen.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/prussianGreen.png)
   @GeneratedYaruColor(0xFF308280)
   static const MaterialColor prussianGreen = _$YaruColors.prussianGreen;
 
   /// Viridian
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/viridian.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/viridian.png)
   @GeneratedYaruColor(0xFF03875B)
   static const MaterialColor viridian = _$YaruColors.viridian;
 
   /// Purple
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/purple.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/purple.png)
   @GeneratedYaruColor(0xFF8856EB)
   static const MaterialColor purple = _$YaruColors.purple;
 
   /// Red
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/red.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/red.png)
   @GeneratedYaruColor(0xFFE61D34)
   static const MaterialColor red = _$YaruColors.red;
 
   /// Blue
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/blue.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/blue.png)
   @GeneratedYaruColor(0xFF0073E5)
   static const MaterialColor blue = _$YaruColors.blue;
 
   /// Magenta
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/magenta.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/magenta.png)
   @GeneratedYaruColor(0xFFBC33DB)
   static const MaterialColor magenta = _$YaruColors.magenta;
 
   /// Kubuntu Blue
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/kubuntuBlue.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/kubuntuBlue.png)
   @GeneratedYaruColor(0xFF0079C1)
   static const MaterialColor kubuntuBlue = _$YaruColors.kubuntuBlue;
 
   /// Lubuntu Blue
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/lubuntuBlue.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/lubuntuBlue.png)
   @GeneratedYaruColor(0xFF0068C8)
   static const MaterialColor lubuntuBlue = _$YaruColors.lubuntuBlue;
 
   /// Ubuntu Budgie Blue
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/ubuntuBudgieBlue.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/ubuntuBudgieBlue.png)
   @GeneratedYaruColor(0xFF2196F3)
   static const MaterialColor ubuntuBudgieBlue = _$YaruColors.ubuntuBudgieBlue;
 
   /// Ubuntu Butterfly Pink
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/ubuntuButterflyPink.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/ubuntuButterflyPink.png)
   @GeneratedYaruColor(0xFFFF135B)
   static const MaterialColor ubuntuButterflyPink =
       _$YaruColors.ubuntuButterflyPink;
 
   /// Ubuntu MATE Green
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/ubuntuMateGreen.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/ubuntuMateGreen.png)
   @GeneratedYaruColor(0xFF73AF59)
   static const MaterialColor ubuntuMateGreen = _$YaruColors.ubuntuMateGreen;
 
   /// Ubuntu Studio Blue
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/ubuntuStudioBlue.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/ubuntuStudioBlue.png)
   @GeneratedYaruColor(0xFF009BF9)
   static const MaterialColor ubuntuStudioBlue = _$YaruColors.ubuntuStudioBlue;
 
   /// Xubuntu Blue
   ///
-  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/screenshots/packages/yaru_colors/example/doc/images/xubuntuBlue.png)
+  /// ![](https://raw.githubusercontent.com/ubuntu/yaru_colors.dart/main/doc/images/xubuntuBlue.png)
   @GeneratedYaruColor(0xFF0044AA)
   static const MaterialColor xubuntuBlue = _$YaruColors.xubuntuBlue;
 }


### PR DESCRIPTION
Apparently, the links never really worked because they've been pointing to the WIP "screenshots" branch all this time... :man_facepalming: 