### PR TITLE
Darken jet

### DIFF
--- a/lib/src/colors.dart
+++ b/lib/src/colors.dart
@@ -64,7 +64,7 @@ class YaruColors {
   static const Color inkstone = Color(0xFF3B3B3B);
 
   /// Jet
-  static const Color jet = Color(0xFF2B2B2B);
+  static const Color jet = Color(0xFF1E1E1E);
 
   /// Light title bar
   static const Color titleBarLight = Color(0xFFEBEBEB);


### PR DESCRIPTION
This darkens the jet color by 5%
![grafik](https://user-images.githubusercontent.com/15329494/220410449-98a8bb5c-bbf2-4823-8213-b3a41fc00198.png)

This color was actually lightened by me some years ago in yaru for some reason I have forgotten. Initially it was `#1a1a1a`

This will help will help with https://github.com/ubuntu/yaru.dart/issues/234