### PR TITLE
CI: pin Melos at 2.9.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@v1
+        with:
+          melos-version: '2.9.0'
       - run: melos analyze
 
   coverage:
@@ -22,6 +24,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@v1
+        with:
+          melos-version: '2.9.0'
       - run: sudo apt install -y lcov
       - run: melos coverage
       - uses: codecov/codecov-action@v3
@@ -34,6 +38,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@v1
+        with:
+          melos-version: '2.9.0'
       - run: melos format
 
   generate:
@@ -42,6 +48,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@v1
+        with:
+          melos-version: '2.9.0'
       - run: melos generate
       - run: ./.github/scripts/check-outdated-files.sh
         if: github.event_name != 'push'
@@ -59,6 +67,8 @@ jobs:
       - run: echo "$HOME/snap/flutter/common/flutter/.pub-cache/bin" >> $GITHUB_PATH
       - run: flutter doctor -v
       - uses: bluefireteam/melos-action@v1
+        with:
+          melos-version: '2.9.0'
       - run: flutter build linux -v
         working-directory: example
 
@@ -67,7 +77,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
-      - run: dart pub global activate melos
+      - run: dart pub global activate melos 2.9.0
       - run: melos exec -c 1 --no-private -- dart pub publish --dry-run
 
   test:
@@ -79,6 +89,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@v1
+        with:
+          melos-version: '2.9.0'
       - run: melos test
 
   web:
@@ -87,6 +99,8 @@ jobs:
       - uses: actions/checkout@v3
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@v1
+        with:
+          melos-version: '2.9.0'
       - run: flutter doctor -v
       - run: flutter build web -v
         working-directory: example


### PR DESCRIPTION
Pin for now, we can migrate to 3.x later.
```
Activated melos 3.0.0.
Running melos bootstrap
Found a melos.yaml file in "/home/runner/work/yaru_colors.dart/yaru_colors.dart" but no local installation of Melos.

From version 3.0.0, the melos package must be installed in a pubspec.yaml file next to the melos.yaml file.

For more information on migrating to version 3.0.0, see: https://melos.invertase.dev/guides/migrations#200-to-300

To migrate at a later time, ensure you have version 2.9.0 or below installed: dart pub global activate melos 2.9.0
```
https://github.com/ubuntu/yaru_colors.dart/actions/runs/4481057352/jobs/7877220307?pr=28